### PR TITLE
Fix microphone config path handling

### DIFF
--- a/helpers/mic.py
+++ b/helpers/mic.py
@@ -1,10 +1,17 @@
-import pyaudio
 import os
 import json
+from pathlib import Path
 
-CONFIG_FILE = "config\mic_config.json"
+DEFAULT_CONFIG_FILE = Path(__file__).resolve().parents[1] / "mic_config.json"
+CONFIG_FILE = Path(os.getenv("BONZI_MIC_CONFIG", DEFAULT_CONFIG_FILE))
+
+
+def _pyaudio():
+    import pyaudio
+    return pyaudio
 
 def list_microphones():
+    pyaudio = _pyaudio()
     p = pyaudio.PyAudio()
     info = p.get_host_api_info_by_index(0)
     num_devices = info.get('deviceCount')
@@ -34,18 +41,20 @@ def get_device_index(num_devices, default_device_index, default_device_name):
         print("Invalid input. Please enter a valid number.")
 
 def load_config():
-    if os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, "r") as f:
+    if CONFIG_FILE.exists():
+        with CONFIG_FILE.open("r") as f:
             return json.load(f)
     return None
 
 def save_config(config):
-    with open(CONFIG_FILE, "w") as f:
+    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with CONFIG_FILE.open("w") as f:
         json.dump(config, f, indent=4)
 
 def configure_microphone():
     print("Available microphones:")
     default_device_name = list_microphones()
+    pyaudio = _pyaudio()
     p = pyaudio.PyAudio()
     num_devices = p.get_host_api_info_by_index(0).get('deviceCount')
     default_device_index = p.get_default_input_device_info().get('index')

--- a/tests/test_mic_config.py
+++ b/tests/test_mic_config.py
@@ -1,0 +1,42 @@
+import importlib
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class MicConfigTests(unittest.TestCase):
+    def reload_mic_with_config(self, config_path):
+        os.environ["BONZI_MIC_CONFIG"] = str(config_path)
+        import helpers.mic as mic
+        return importlib.reload(mic)
+
+    def tearDown(self):
+        os.environ.pop("BONZI_MIC_CONFIG", None)
+
+    def test_load_config_returns_none_when_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mic = self.reload_mic_with_config(Path(tmp) / "missing" / "mic_config.json")
+            self.assertIsNone(mic.load_config())
+
+    def test_save_config_creates_parent_directory_and_round_trips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "config" / "mic_config.json"
+            mic = self.reload_mic_with_config(config_path)
+
+            mic.save_config({"device_index": 3, "prompt_every_time": False})
+
+            self.assertTrue(config_path.exists())
+            self.assertEqual(
+                json.loads(config_path.read_text()),
+                {"device_index": 3, "prompt_every_time": False},
+            )
+            self.assertEqual(
+                mic.load_config(),
+                {"device_index": 3, "prompt_every_time": False},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes dot-Justin/BonziAssist#7
/claim #7

Summary:
- load microphone config from the repository root `mic_config.json` by default instead of `config\mic_config.json`
- allow `BONZI_MIC_CONFIG` to override the config path for tests or custom installs
- create the config parent directory when saving and lazy-load `pyaudio` so config load/save can be tested without audio hardware bindings
- add stdlib `unittest` coverage for missing config and save/load round trip

Why:
- the repo ships `mic_config.json` in the project root, but `helpers/mic.py` looked for a Windows-style `config\mic_config.json` path and emitted a Python invalid escape warning
- first-run microphone setup could fail when trying to save into a missing `config` directory

Verification:
- `python3 -m unittest discover -s tests`
- `python3 -m py_compile main.py helpers/*.py tests/*.py`
- `git diff --check`

No private credentials, tokens, or local config values are included.
