### PR TITLE
Fix first-run microphone configuration

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,8 +14,17 @@ BonziAssist revives the classic BonziBuddy assistant in a modern, voice-activate
 
 ### Installation
 1. Clone this repository.
-2. Ensure you have [Python](https://www.python.org/downloads/) and [Visual CPP Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). installed, and then run `pip install -r requirements.txt` to install the necessary packages.
-4. Set up your environment variables. Edit the `.env.example` file in `helpers\` and follow the instructions there. `[INSTRUCTIONS='Remove this line of instructions. Fill out the info below. Rename this file, and remove the .example. It should just be ".env" now.']`
+2. Open a terminal from the repository root.
+3. Ensure you have [Python](https://www.python.org/downloads/) and [Visual CPP Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) installed.
+4. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+5. Create your environment file:
+```bash
+copy helpers\.env.example helpers\.env
+```
+6. Edit `helpers\.env` and replace `your-api-key-here` with your API key.
 
 ### Usage
 To start BonziAssist:
@@ -23,7 +32,9 @@ To start BonziAssist:
 python main.py
 ```
 
-You will be prompted to configure your microphone settings upon the first run or if you choose to be prompted every time by the configuration settings.
+You will be prompted to configure your microphone settings on the first run, or when `prompt_every_time` is enabled in `mic_config.json`.
+
+BonziAssist stores microphone selection in `mic_config.json` in the repository root. To use a different config file, set `BONZI_MIC_CONFIG` to that path before running `python main.py`.
 
 ## TODO
 

--- a/helpers/mic.py
+++ b/helpers/mic.py
@@ -1,10 +1,24 @@
-import pyaudio
 import os
 import json
+from pathlib import Path
 
-CONFIG_FILE = "config\mic_config.json"
+DEFAULT_CONFIG_FILE = Path(__file__).resolve().parents[1] / "mic_config.json"
+
+
+def get_config_file():
+    override = os.getenv("BONZI_MIC_CONFIG")
+    if override:
+        return Path(override).expanduser()
+    return DEFAULT_CONFIG_FILE
+
+
+def get_pyaudio():
+    import pyaudio
+
+    return pyaudio
 
 def list_microphones():
+    pyaudio = get_pyaudio()
     p = pyaudio.PyAudio()
     info = p.get_host_api_info_by_index(0)
     num_devices = info.get('deviceCount')
@@ -34,18 +48,26 @@ def get_device_index(num_devices, default_device_index, default_device_name):
         print("Invalid input. Please enter a valid number.")
 
 def load_config():
-    if os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, "r") as f:
-            return json.load(f)
+    config_file = get_config_file()
+    if config_file.exists():
+        with config_file.open("r", encoding="utf-8") as f:
+            config = json.load(f)
+        if "device_index" not in config and "mic_index" in config:
+            config["device_index"] = config["mic_index"]
+        config.setdefault("prompt_every_time", False)
+        return config
     return None
 
 def save_config(config):
-    with open(CONFIG_FILE, "w") as f:
+    config_file = get_config_file()
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    with config_file.open("w", encoding="utf-8") as f:
         json.dump(config, f, indent=4)
 
 def configure_microphone():
     print("Available microphones:")
     default_device_name = list_microphones()
+    pyaudio = get_pyaudio()
     p = pyaudio.PyAudio()
     num_devices = p.get_host_api_info_by_index(0).get('deviceCount')
     default_device_index = p.get_default_input_device_info().get('index')

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from helpers import mic, llm, tts
+from helpers import mic
 import pyaudio
 import wave
 import random
@@ -60,6 +60,8 @@ def listen_for_bonzi(device_index=None):
             if command_active:
                 # Directly use the first captured text as the command
                 if text:
+                    from helpers import llm, tts
+
                     llm_response = llm.request(text.strip())
                     print(f"LLM response: {llm_response}")
                     tts.say(llm_response)
@@ -75,5 +77,5 @@ if __name__ == "__main__":
     config = mic.load_config()
     if config is None or config.get("prompt_every_time", False):
         config = mic.configure_microphone()
-    device_index = config['device_index']
+    device_index = config["device_index"]
     listen_for_bonzi(device_index)

--- a/tests/test_mic_config.py
+++ b/tests/test_mic_config.py
@@ -1,0 +1,48 @@
+import importlib
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class MicConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.previous_config = os.environ.get("BONZI_MIC_CONFIG")
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.config_path = Path(self.tempdir.name) / "nested" / "mic_config.json"
+        os.environ["BONZI_MIC_CONFIG"] = str(self.config_path)
+
+        import helpers.mic as mic
+
+        self.mic = importlib.reload(mic)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+        if self.previous_config is None:
+            os.environ.pop("BONZI_MIC_CONFIG", None)
+        else:
+            os.environ["BONZI_MIC_CONFIG"] = self.previous_config
+
+    def test_missing_config_returns_none(self):
+        self.assertIsNone(self.mic.load_config())
+
+    def test_legacy_mic_index_is_accepted(self):
+        self.config_path.parent.mkdir(parents=True)
+        self.config_path.write_text(json.dumps({"mic_index": 53}), encoding="utf-8")
+
+        config = self.mic.load_config()
+
+        self.assertEqual(config["device_index"], 53)
+        self.assertFalse(config["prompt_every_time"])
+
+    def test_save_config_creates_parent_directory(self):
+        self.mic.save_config({"device_index": 7, "prompt_every_time": True})
+
+        config = json.loads(self.config_path.read_text(encoding="utf-8"))
+        self.assertEqual(config["device_index"], 7)
+        self.assertTrue(config["prompt_every_time"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #7
/claim #7

Summary:
- Load the microphone config from the repository root by default and support BONZI_MIC_CONFIG for custom paths.
- Accept legacy mic_config.json files that use mic_index and normalize them to device_index.
- Lazy-load PyAudio plus the LLM/TTS helpers so first-run microphone setup is not blocked before configuration.
- Document the first-run setup flow and root mic_config.json location.
- Add unittest coverage for missing config, legacy config compatibility, and save path creation.

Verification:
- python -m unittest tests.test_mic_config -v
- python -m py_compile main.py helpers/mic.py helpers/llm.py helpers/tts.py tests/test_mic_config.py
