### PR TITLE
Fix startup: auto-download Vosk model, fix mic config path, add setup.sh

### DIFF
--- a/helpers/mic.py
+++ b/helpers/mic.py
@@ -2,7 +2,7 @@ import pyaudio
 import os
 import json
 
-CONFIG_FILE = "config\mic_config.json"
+CONFIG_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), "mic_config.json")
 
 def list_microphones():
     p = pyaudio.PyAudio()

--- a/main.py
+++ b/main.py
@@ -3,9 +3,36 @@ import pyaudio
 import wave
 import random
 import os
+import sys
 import time
 import json
+import urllib.request
+import zipfile
+from pathlib import Path
 from vosk import Model, KaldiRecognizer
+
+
+def ensure_vosk_model(model_dir="vosk"):
+    model_name = "vosk-model-small-en-us-0.15"
+    model_path = Path(model_dir) / model_name
+    if model_path.exists():
+        return str(model_path)
+
+    os.makedirs(model_dir, exist_ok=True)
+    print(f"Vosk model not found at {model_path}. Downloading...")
+    url = f"https://alphacephei.com/vosk/models/{model_name}.zip"
+    zip_path = Path(f"/tmp/{model_name}.zip")
+    try:
+        urllib.request.urlretrieve(url, zip_path)
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            zf.extractall(model_dir)
+        zip_path.unlink()
+        print(f"Model downloaded to {model_path}")
+    except Exception as e:
+        print(f"Failed to download Vosk model: {e}")
+        print(f"Please manually download from: https://alphacephei.com/vosk/models")
+        sys.exit(1)
+    return str(model_path)
 
 class BonziResponse:
     def __init__(self, canned_directory="canned_responses/"):
@@ -37,9 +64,8 @@ class BonziResponse:
         response = random.choice(self.canned_responses)
         self.play_audio(response)
 
-def listen_for_bonzi(device_index=None):
-    model_path = "vosk/vosk-model-small-en-us-0.15"
-    model = Model(model_path)
+def listen_for_bonzi(vosk_model_path, device_index=None):
+    model = Model(vosk_model_path)
     recognizer = KaldiRecognizer(model, 16000)
 
     bonzi_response = BonziResponse()
@@ -72,8 +98,9 @@ def listen_for_bonzi(device_index=None):
                 command_active = True  # Enable command capture
 
 if __name__ == "__main__":
+    vosk_model_path = ensure_vosk_model()
     config = mic.load_config()
     if config is None or config.get("prompt_every_time", False):
         config = mic.configure_microphone()
     device_index = config['device_index']
-    listen_for_bonzi(device_index)
+    listen_for_bonzi(vosk_model_path, device_index)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# BonziAssist setup script
+set -e
+
+echo "=== BonziAssist Setup ==="
+
+# Check Python
+command -v python3 >/dev/null 2>&1 || { echo "Python 3 required. Install from https://www.python.org/downloads/"; exit 1; }
+
+# Check for .env
+if [ ! -f helpers/.env ]; then
+    echo ""
+    echo "Creating helpers/.env from template..."
+    cp helpers/.env.example helpers/.env
+    echo "Please edit helpers/.env and set your GROQ_API_KEY"
+    echo "Get a key at: https://console.groq.com/keys"
+    echo ""
+fi
+
+# Install deps
+echo "Installing dependencies..."
+pip install -r requirements.txt
+
+echo ""
+echo "Done! Run: python3 main.py"


### PR DESCRIPTION
Fixes #7

## Changes

**Auto-download Vosk model**: If `vosk-model-small-en-us-0.15` is not found, it is automatically downloaded from Alphacephei on first run. No manual download needed.

**Fix mic config path**: `CONFIG_FILE` used a Windows backslash path `config\mic_config.json` which failed on Linux/macOS and was in the wrong directory. Fixed to use `os.path.join` pointing to the correct root-level path.

**Add `setup.sh`**: Guided setup script that checks Python, creates `.env` from template, and installs dependencies.

## How to start (after this fix)
```bash
# 1. Edit helpers/.env with your GROQ_API_KEY
# 2. Run:
python3 main.py
```
The Vosk model downloads automatically on first run.
