### PR TITLE
fix: cross-platform compatibility and improved setup experience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# BonziAssist Environment Configuration
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+
+# LLM Provider (e.g., groq, openai, anthropic)
+LLM_PROVIDER=groq
+
+# API Key for your chosen LLM provider
+GROQ_API_KEY=your-api-key-here

--- a/README.MD
+++ b/README.MD
@@ -5,7 +5,7 @@
 ## BonziAssist: Your New (Old) Assistant!
 This project uses the [TETYYS generator](https://www.tetyys.com/SAPI4/). Also see: [BonziBuddy-TTS](https://github.com/dot-Justin/BonziBuddy-TTS).
 ### ⚠️ Do Not Abuse the API ⚠️
-BonziAssist revives the classic BonziBuddy assistant in a modern, voice-activated form, allowing you to interact with an AI through spoken commands. Here’s a bit more about what makes BonziAssist special and how to use it.
+BonziAssist revives the classic BonziBuddy assistant in a modern, voice-activated form, allowing you to interact with an AI through spoken commands. Here's a bit more about what makes BonziAssist special and how to use it.
 
 ### Features
 - **Voice Activation**: Simply say "`Bonzi`" and once you hear Bonzi confirm he's listening, you're ready to go!
@@ -13,9 +13,32 @@ BonziAssist revives the classic BonziBuddy assistant in a modern, voice-activate
 - **Real-Time Interaction**: Communicate in real-time, with responses generated through a lightweight LLM.
 
 ### Installation
-1. Clone this repository.
-2. Ensure you have [Python](https://www.python.org/downloads/) and [Visual CPP Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). installed, and then run `pip install -r requirements.txt` to install the necessary packages.
-4. Set up your environment variables. Edit the `.env.example` file in `helpers\` and follow the instructions there. `[INSTRUCTIONS='Remove this line of instructions. Fill out the info below. Rename this file, and remove the .example. It should just be ".env" now.']`
+
+1. **Clone this repository:**
+   ```bash
+   git clone https://github.com/dot-Justin/BonziAssist.git
+   cd BonziAssist
+   ```
+
+2. **Install Python 3.8+** from [python.org](https://www.python.org/downloads/).
+   - **Windows users:** Also install [Visual CPP Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+
+3. **Install dependencies:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. **Set up your environment variables:**
+   ```bash
+   cp .env.example .env
+   ```
+   Then edit `.env` and fill in your API key. You'll need:
+   - `LLM_PROVIDER` — your LLM provider (e.g., `groq`, `openai`)
+   - `GROQ_API_KEY` — your API key for the chosen provider
+
+5. **Download the VOSK speech recognition model:**
+   - Download [vosk-model-small-en-us-0.15](https://alphacephei.com/vosk/models/vosk-model-small-en-us-0.15.zip)
+   - Extract it into the `vosk/` directory so the path looks like: `vosk/vosk-model-small-en-us-0.15/`
 
 ### Usage
 To start BonziAssist:

--- a/helpers/mic.py
+++ b/helpers/mic.py
@@ -2,7 +2,7 @@ import pyaudio
 import os
 import json
 
-CONFIG_FILE = "config\mic_config.json"
+CONFIG_FILE = os.path.join("config", "mic_config.json")
 
 def list_microphones():
     p = pyaudio.PyAudio()

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ import json
 from vosk import Model, KaldiRecognizer
 
 class BonziResponse:
-    def __init__(self, canned_directory="canned_responses/"):
+    def __init__(self, canned_directory=os.path.join("canned_responses", "")):
         self.canned_directory = canned_directory
         self.canned_responses = [os.path.join(canned_directory, f) for f in os.listdir(canned_directory) if f.endswith('.wav')]
         self.preloaded_audio = self.preload_audio_files()
@@ -38,7 +38,11 @@ class BonziResponse:
         self.play_audio(response)
 
 def listen_for_bonzi(device_index=None):
-    model_path = "vosk/vosk-model-small-en-us-0.15"
+    model_path = os.path.join("vosk", "vosk-model-small-en-us-0.15")
+    if not os.path.exists(model_path):
+        print(f"Error: VOSK model not found at '{model_path}'.")
+        print("Download it from https://alphacephei.com/vosk/models and extract to the 'vosk/' directory.")
+        return
     model = Model(model_path)
     recognizer = KaldiRecognizer(model, 16000)
 


### PR DESCRIPTION
Fixes #7

The main issue: this project does not work on macOS/Linux out of the box.

What I changed:

**helpers/mic.py** — The config path was hardcoded with Windows backslashes. Swapped to `os.path.join` so it works everywhere.

**main.py** — Same deal with the VOSK model path. Also added a check so you get a clear error message if the model is not downloaded yet, instead of a random traceback.

**.env.example** — Added one in the project root. The existing one was buried in `helpers/` but `load_dotenv()` looks in the working directory. Now users can just `cp .env.example .env` and edit.

**README** — Rewrote the setup section with actual step-by-step instructions. The original was missing the VOSK download step entirely, which is probably why #7 was opened.