### PR TITLE
Fix first-run setup and startup diagnostics

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,82 +1,81 @@
 <div style="text-align: center;">
-    <img src="assets/BonziASSIST_bg.png" alt="BonziAssist" style="width:70%; height:auto;">
+    <img src="assets/BonziASSIST_bg.png" alt="Shiny Text" style="width:70%; height:auto;">
 </div>
 
 ## BonziAssist: Your New (Old) Assistant!
+This project uses the [TETYYS generator](https://www.tetyys.com/SAPI4/). Also see: [BonziBuddy-TTS](https://github.com/dot-Justin/BonziBuddy-TTS).
+### ⚠️ Do Not Abuse the API ⚠️
+BonziAssist revives the classic BonziBuddy assistant in a modern, voice-activated form, allowing you to interact with an AI through spoken commands.
 
-BonziAssist is a voice-activated assistant using Vosk speech recognition, LiteLLM, and the TETYYS SAPI4 voice API.
-
-### Prerequisites
-
-- Python 3
-- Visual C++ Build Tools on Windows, as required by PyAudio
-- A microphone
-- A LiteLLM-compatible API key configured in `helpers/.env`
-- The Vosk model `vosk-model-small-en-us-0.15`
+### Features
+- **Voice Activation**: Simply say "`Bonzi`" and once you hear Bonzi confirm he's listening, you're ready to go!
+- **Text-to-Speech**: Utilizes the nostalgic BonziBuddy voice for responses, thanks to the [TETYYS SAPI4 API](https://www.tetyys.com/SAPI4/).
+- **Real-Time Interaction**: Communicate in real-time, with responses generated through a lightweight LLM.
 
 ### Installation
-
-1. Clone the repository and enter it:
-
+1. Clone this repository and enter it:
    ```bash
    git clone https://github.com/dot-Justin/BonziAssist.git
    cd BonziAssist
    ```
-
-2. Install dependencies:
-
+2. Ensure you have [Python](https://www.python.org/downloads/) and [Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) on Windows, then install the dependencies:
    ```bash
    python -m pip install -r requirements.txt
    ```
-
-3. Configure the environment file:
-
-   - Copy `helpers/.env.example` to `helpers/.env`.
-   - Remove the instruction line and provide the requested API configuration.
-
-4. Download `vosk-model-small-en-us-0.15` from the [Vosk models page](https://alphacephei.com/vosk/models).
-
-5. Extract it to:
-
+3. Copy `helpers/.env.example` to `.env` in the repository root. Remove the instruction line and fill in `LLM_PROVIDER` and `GROQ_API_KEY`.
+4. Download `vosk-model-small-en-us-0.15` from the [Vosk models page](https://alphacephei.com/vosk/models) and extract it to:
    ```text
    BonziAssist/vosk/vosk-model-small-en-us-0.15/
    ```
-
-   A different location can be used by setting `BONZI_VOSK_MODEL` to the extracted model directory.
+   To keep the model elsewhere, set `BONZI_VOSK_MODEL` to the extracted model directory.
 
 ### Usage
-
 Start BonziAssist from the repository root:
-
 ```bash
 python main.py
 ```
 
-On the first run, select a microphone. The selection is stored in the repository-root `mic_config.json`. Set `BONZI_MIC_CONFIG` to use a custom configuration path.
-
-Startup now reports an actionable error when the Vosk model is missing instead of failing inside the Vosk library.
+You will be prompted to configure your microphone settings on the first run. The selection is stored in `mic_config.json`. Delete that file to select a different microphone, or set `BONZI_MIC_CONFIG` to use a custom configuration path.
 
 ### Troubleshooting
-
 - **Vosk model not found:** verify the extracted folder name and location, or set `BONZI_VOSK_MODEL`.
-- **Microphone selection is wrong:** delete `mic_config.json` and start again.
-- **PyAudio installation fails:** install the platform audio development tools and Visual C++ Build Tools on Windows, then retry the dependency installation.
-- **Environment values are missing:** verify that `helpers/.env` exists and contains the values described in `helpers/.env.example`.
+- **Environment values are missing:** verify that `.env` exists in the repository root and contains the values from `helpers/.env.example`.
+- **PyAudio installation fails:** install the platform audio development tools and Visual C++ Build Tools on Windows, then retry dependency installation.
 
-### Features
+## TODO
 
-- Voice activation using the word “Bonzi” and common recognition variants
-- Speech recognition through Vosk
-- Responses generated through LiteLLM
-- BonziBuddy-style text-to-speech through TETYYS SAPI4
+- [x] **Add LiteLLM**: Enable Bonzi to talk back to you
+- [ ] **HIGH PRIO: Improve STT Accuracy**: Potentially use a bigger VOSK model
+- [ ] **Improve STT Speed**: Potentially use a different package
+- [ ] **Improve TTS Speed**: Find a way to run locally for quicker responses
+- [ ] **Offline Functionality**: Use fully offline APIs such as Ollama for those with beefier computers
+- [ ] **Add Voice Volume Control**
+- [ ] **Add simple windows functions**: Such as Media control, opening apps, etc.
+- [ ] **Add interruption support**: Potentially via a hotkey (press esc to interrupt)
+- [ ] **Add fancy splash screen**
+
+#### Continuous goals
+
+- When VOSK misunderstands, add to the list of phrases Bonzi will respond to
+- Update system prompt to give more personality and functionality
+- Optimize Performance
+
+Contributors are welcome to help with these tasks. If you are interested, please fork the repository, make your changes, and submit a pull request. If you have any questions, feel free to open an issue and ask away!
+
+## How it Works
+1. Listening: The system starts by listening for the activation word "Bonzi". Once heard, it's ready to receive commands.
+2. Processing: Speech is converted to text and processed by an LLM to understand the context and generate an appropriate response.
+3. Responding: The response is then converted to speech using the SAPI4 API, maintaining the classic voice of BonziBuddy.
 
 ## Contributing
-
-Contributions are welcome. For major changes, open an issue first to discuss the proposed scope.
+First of all, I appreciate anyone being excited about this project. That being said, contributions are welcome! For major changes, please open an issue first to discuss what you would like to change.
 
 ## Acknowledgments
-
-- [TETYYS SAPI4](https://www.tetyys.com/SAPI4/)
-- [BonziBuddy-TTS](https://github.com/dot-Justin/BonziBuddy-TTS)
-- [Vosk](https://alphacephei.com/vosk/)
-- LiteLLM, SimpleAudio, PyAudio, and Python-dotenv
+- **SAPI4**: The Text-to-Speech engine that allows BonziAssist to speak with the classic BonziBuddy voice. [Visit TETYYS's online SAPI4](https://www.tetyys.com/SAPI4/).
+- **BonziBuddy-TTS GitHub Project**: Inspired the integration of the BonziBuddy voice into this project. [View the repository](https://github.com/dot-Justin/BonziBuddy-TTS).
+- **Vosk Speech Recognition**: Provides the voice recognition capabilities required to interpret user commands. [Learn more about Vosk](https://alphacephei.com/vosk/).
+- **LiteLLM**: For processing natural language and generating appropriate responses.
+- **SimpleAudio**: Used for playing back audio responses generated by the system.
+- **PyAudio**: Handles microphone input and audio stream management.
+- **Python-dotenv**: For managing environment variables in a `.env` file.
+- **GitHub Community**: For all open-source contributors who developed the libraries used by this project.

--- a/README.MD
+++ b/README.MD
@@ -1,63 +1,82 @@
 <div style="text-align: center;">
-    <img src="assets/BonziASSIST_bg.png" alt="Shiny Text" style="width:70%; height:auto;">
+    <img src="assets/BonziASSIST_bg.png" alt="BonziAssist" style="width:70%; height:auto;">
 </div>
 
 ## BonziAssist: Your New (Old) Assistant!
-This project uses the [TETYYS generator](https://www.tetyys.com/SAPI4/). Also see: [BonziBuddy-TTS](https://github.com/dot-Justin/BonziBuddy-TTS).
-### ⚠️ Do Not Abuse the API ⚠️
-BonziAssist revives the classic BonziBuddy assistant in a modern, voice-activated form, allowing you to interact with an AI through spoken commands. Here’s a bit more about what makes BonziAssist special and how to use it.
 
-### Features
-- **Voice Activation**: Simply say "`Bonzi`" and once you hear Bonzi confirm he's listening, you're ready to go!
-- **Text-to-Speech**: Utilizes the nostalgic BonziBuddy voice for responses, thanks to the [TETYYS SAPI4 API](https://www.tetyys.com/SAPI4/).
-- **Real-Time Interaction**: Communicate in real-time, with responses generated through a lightweight LLM.
+BonziAssist is a voice-activated assistant using Vosk speech recognition, LiteLLM, and the TETYYS SAPI4 voice API.
+
+### Prerequisites
+
+- Python 3
+- Visual C++ Build Tools on Windows, as required by PyAudio
+- A microphone
+- A LiteLLM-compatible API key configured in `helpers/.env`
+- The Vosk model `vosk-model-small-en-us-0.15`
 
 ### Installation
-1. Clone this repository.
-2. Ensure you have [Python](https://www.python.org/downloads/) and [Visual CPP Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). installed, and then run `pip install -r requirements.txt` to install the necessary packages.
-4. Set up your environment variables. Edit the `.env.example` file in `helpers\` and follow the instructions there. `[INSTRUCTIONS='Remove this line of instructions. Fill out the info below. Rename this file, and remove the .example. It should just be ".env" now.']`
+
+1. Clone the repository and enter it:
+
+   ```bash
+   git clone https://github.com/dot-Justin/BonziAssist.git
+   cd BonziAssist
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+
+3. Configure the environment file:
+
+   - Copy `helpers/.env.example` to `helpers/.env`.
+   - Remove the instruction line and provide the requested API configuration.
+
+4. Download `vosk-model-small-en-us-0.15` from the [Vosk models page](https://alphacephei.com/vosk/models).
+
+5. Extract it to:
+
+   ```text
+   BonziAssist/vosk/vosk-model-small-en-us-0.15/
+   ```
+
+   A different location can be used by setting `BONZI_VOSK_MODEL` to the extracted model directory.
 
 ### Usage
-To start BonziAssist:
+
+Start BonziAssist from the repository root:
+
 ```bash
 python main.py
 ```
 
-You will be prompted to configure your microphone settings upon the first run or if you choose to be prompted every time by the configuration settings.
+On the first run, select a microphone. The selection is stored in the repository-root `mic_config.json`. Set `BONZI_MIC_CONFIG` to use a custom configuration path.
 
-## TODO
+Startup now reports an actionable error when the Vosk model is missing instead of failing inside the Vosk library.
 
-- [x] **Add LiteLLM**: Enable Bonzi to talk back to you
-- [ ] **HIGH PRIO: Improve STT Accuracy**: Potentially use a bigger VOSK model
-- [ ] **Improve STT Speed**: Potentially use a different package
-- [ ] **Improve TTS Speed**: Find a way to run locally for quicker responses
-- [ ] **Offline Functionality**: Use fully offline APIs such as Ollama for those with beefier computers
-- [ ] **Add Voice Volume Control**
-- [ ] **Add simple windows functions**: Such as Media control, opening apps, etc.
-- [ ] **Add interruption support**: Potentially via a hotkey (press esc to interrupt)
-- [ ] **Add fancy splash screen**
+### Troubleshooting
 
-#### Continuous goals
+- **Vosk model not found:** verify the extracted folder name and location, or set `BONZI_VOSK_MODEL`.
+- **Microphone selection is wrong:** delete `mic_config.json` and start again.
+- **PyAudio installation fails:** install the platform audio development tools and Visual C++ Build Tools on Windows, then retry the dependency installation.
+- **Environment values are missing:** verify that `helpers/.env` exists and contains the values described in `helpers/.env.example`.
 
-- When VOSK misunderstands, add to the list of phrases Bonzi will respond to
-- Update system prompt to give more personality and functionality
-- Optimize Performance
+### Features
 
-Contributors are welcome to help with these tasks. If you are interested, please fork the repository, make your changes, and submit a pull request. If you have any questions, feel free to open an issue and ask away!
+- Voice activation using the word “Bonzi” and common recognition variants
+- Speech recognition through Vosk
+- Responses generated through LiteLLM
+- BonziBuddy-style text-to-speech through TETYYS SAPI4
 
-## How it Works
-1. Listening: The system starts by listening for the activation word "Bonzi". Once heard, it's ready to receive commands.
-2. Processing: Speech is converted to text and processed by an LLM to understand the context and generate an appropriate response.
-3. Responding: The response is then converted to speech using the SAPI4 API, maintaining the classic voice of BonziBuddy.
 ## Contributing
-First of all, I appreciate anyone being excited about this project. That being said, contributions are welcome! For major changes, please open an issue first to discuss what you would like to change.
+
+Contributions are welcome. For major changes, open an issue first to discuss the proposed scope.
 
 ## Acknowledgments
-- **SAPI4**: The Text-to-Speech engine that allows BonziAssist to speak with the classic BonziBuddy voice. [Visit TETYYS's online SAPI4](https://www.tetyys.com/SAPI4/).
-- **BonziBuddy-TTS GitHub Project**: Inspired the integration of the BonziBuddy voice into this project. [View the repository](https://github.com/dot-Justin/BonziBuddy-TTS).
-- **Vosk Speech Recognition**: Provides the voice recognition capabilities required to interpret user commands. [Learn more about Vosk](https://alphacephei.com/vosk/).
-- **LitteLLM**: For processing natural language and generating responses. Their LLM services form the backbone of BonziAssist's AI capabilities.
-- **SimpleAudio**: Used for playing back audio responses generated by the system.
-- **PyAudio**: Handles microphone input and audio stream management.
-- **Python-dotenv**: For managing environment variables in a .env file, which helps secure API keys and other sensitive settings.
-- **GitHub Community**: For all the open-source contributors who have developed libraries and tools that made this project feasible.
+
+- [TETYYS SAPI4](https://www.tetyys.com/SAPI4/)
+- [BonziBuddy-TTS](https://github.com/dot-Justin/BonziBuddy-TTS)
+- [Vosk](https://alphacephei.com/vosk/)
+- LiteLLM, SimpleAudio, PyAudio, and Python-dotenv

--- a/helpers/mic.py
+++ b/helpers/mic.py
@@ -1,60 +1,93 @@
-import pyaudio
-import os
+from __future__ import annotations
+
 import json
+import os
+from pathlib import Path
+from typing import Any
 
-CONFIG_FILE = "config\mic_config.json"
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG_FILE = PROJECT_ROOT / "mic_config.json"
 
-def list_microphones():
-    p = pyaudio.PyAudio()
-    info = p.get_host_api_info_by_index(0)
-    num_devices = info.get('deviceCount')
 
-    default_device_index = p.get_default_input_device_info().get('index')
-    default_device_name = p.get_device_info_by_index(default_device_index).get('name')
+def config_file() -> Path:
+    override = os.environ.get("BONZI_MIC_CONFIG")
+    return Path(override).expanduser() if override else DEFAULT_CONFIG_FILE
 
-    for i in range(num_devices):
-        device_info = p.get_device_info_by_host_api_device_index(0, i)
-        if device_info.get('maxInputChannels') > 0:
-            if i == default_device_index:
-                print(f"{i}: - {device_info.get('name')} (default)")
-            else:
-                print(f"{i}: - {device_info.get('name')}")
-    p.terminate()
-    return default_device_name
 
-def get_device_index(num_devices, default_device_index, default_device_name):
+def _pyaudio():
+    import pyaudio
+
+    return pyaudio
+
+
+def list_microphones() -> str:
+    pyaudio = _pyaudio()
+    audio = pyaudio.PyAudio()
+    try:
+        info = audio.get_host_api_info_by_index(0)
+        num_devices = info.get("deviceCount")
+        default_device_index = audio.get_default_input_device_info().get("index")
+        default_device_name = audio.get_device_info_by_index(default_device_index).get("name")
+
+        for index in range(num_devices):
+            device_info = audio.get_device_info_by_host_api_device_index(0, index)
+            if device_info.get("maxInputChannels") > 0:
+                suffix = " (default)" if index == default_device_index else ""
+                print(f"{index}: - {device_info.get('name')}{suffix}")
+        return default_device_name
+    finally:
+        audio.terminate()
+
+
+def get_device_index(num_devices: int, default_device_index: int, default_device_name: str) -> int:
     while True:
-        user_input = input(f"Enter the Input Device id you want to use (enter = '{default_device_name}'): ").strip()
-        if user_input == "":
-            return default_device_index  # Default to the default device if no input is given
+        user_input = input(
+            f"Enter the Input Device id you want to use (enter = '{default_device_name}'): "
+        ).strip()
+        if not user_input:
+            return default_device_index
         if user_input.isdigit():
             device_index = int(user_input)
             if 0 <= device_index < num_devices:
                 return device_index
         print("Invalid input. Please enter a valid number.")
 
-def load_config():
-    if os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, "r") as f:
-            return json.load(f)
-    return None
 
-def save_config(config):
-    with open(CONFIG_FILE, "w") as f:
-        json.dump(config, f, indent=4)
+def load_config() -> dict[str, Any] | None:
+    path = config_file()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict) or not isinstance(payload.get("device_index"), int):
+        return None
+    return payload
 
-def configure_microphone():
+
+def save_config(config: dict[str, Any]) -> None:
+    path = config_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=4) + "\n", encoding="utf-8")
+
+
+def configure_microphone() -> dict[str, Any]:
     print("Available microphones:")
     default_device_name = list_microphones()
-    p = pyaudio.PyAudio()
-    num_devices = p.get_host_api_info_by_index(0).get('deviceCount')
-    default_device_index = p.get_default_input_device_info().get('index')
-    p.terminate()
+    pyaudio = _pyaudio()
+    audio = pyaudio.PyAudio()
+    try:
+        num_devices = audio.get_host_api_info_by_index(0).get("deviceCount")
+        default_device_index = audio.get_default_input_device_info().get("index")
+    finally:
+        audio.terminate()
+
     device_index = get_device_index(num_devices, default_device_index, default_device_name)
-    prompt_every_time = input("Do you want to be prompted to select a microphone every time? (y/n): ").strip().lower()
+    prompt_every_time = input(
+        "Do you want to be prompted to select a microphone every time? (y/n): "
+    ).strip().lower()
     config = {
         "device_index": device_index,
-        "prompt_every_time": prompt_every_time == 'y'
+        "prompt_every_time": prompt_every_time == "y",
     }
     save_config(config)
     return config

--- a/main.py
+++ b/main.py
@@ -1,79 +1,126 @@
-from helpers import mic, llm, tts
-import pyaudio
-import wave
-import random
-import os
-import time
+from __future__ import annotations
+
 import json
-from vosk import Model, KaldiRecognizer
+import os
+import random
+import time
+import wave
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+DEFAULT_MODEL_PATH = PROJECT_ROOT / "vosk" / "vosk-model-small-en-us-0.15"
+
+
+def resolve_model_path() -> Path:
+    override = os.environ.get("BONZI_VOSK_MODEL")
+    path = Path(override).expanduser() if override else DEFAULT_MODEL_PATH
+    if not path.is_dir():
+        raise FileNotFoundError(
+            "Vosk model not found. Download 'vosk-model-small-en-us-0.15', place it at "
+            f"'{DEFAULT_MODEL_PATH}', or set BONZI_VOSK_MODEL to its directory."
+        )
+    return path
+
 
 class BonziResponse:
-    def __init__(self, canned_directory="canned_responses/"):
-        self.canned_directory = canned_directory
-        self.canned_responses = [os.path.join(canned_directory, f) for f in os.listdir(canned_directory) if f.endswith('.wav')]
+    def __init__(self, canned_directory: Path | None = None) -> None:
+        self.canned_directory = canned_directory or PROJECT_ROOT / "canned_responses"
+        self.canned_responses = sorted(self.canned_directory.glob("*.wav"))
+        if not self.canned_responses:
+            raise FileNotFoundError(f"No canned response WAV files found in '{self.canned_directory}'.")
         self.preloaded_audio = self.preload_audio_files()
 
-    def preload_audio_files(self):
-        audio_files = {}
+    def preload_audio_files(self) -> dict[Path, bytes]:
+        audio_files: dict[Path, bytes] = {}
         for file_path in self.canned_responses:
-            wf = wave.open(file_path, 'rb')
-            audio_files[file_path] = wf.readframes(wf.getnframes())
+            with wave.open(str(file_path), "rb") as audio_file:
+                audio_files[file_path] = audio_file.readframes(audio_file.getnframes())
         return audio_files
 
-    def play_audio(self, file_path):
+    def play_audio(self, file_path: Path) -> None:
+        import pyaudio
+
         audio_data = self.preloaded_audio[file_path]
-        p = pyaudio.PyAudio()
-        wf = wave.open(file_path, 'rb')
-        stream = p.open(format=p.get_format_from_width(wf.getsampwidth()),
-                        channels=wf.getnchannels(),
-                        rate=wf.getframerate(),
-                        output=True)
-        stream.write(audio_data)
-        stream.stop_stream()
-        stream.close()
-        p.terminate()
+        audio = pyaudio.PyAudio()
+        with wave.open(str(file_path), "rb") as audio_file:
+            stream = audio.open(
+                format=audio.get_format_from_width(audio_file.getsampwidth()),
+                channels=audio_file.getnchannels(),
+                rate=audio_file.getframerate(),
+                output=True,
+            )
+            try:
+                stream.write(audio_data)
+            finally:
+                stream.stop_stream()
+                stream.close()
+                audio.terminate()
 
-    def play_random_response(self):
-        response = random.choice(self.canned_responses)
-        self.play_audio(response)
+    def play_random_response(self) -> None:
+        self.play_audio(random.choice(self.canned_responses))
 
-def listen_for_bonzi(device_index=None):
-    model_path = "vosk/vosk-model-small-en-us-0.15"
-    model = Model(model_path)
+
+def listen_for_bonzi(device_index: int | None = None) -> None:
+    import pyaudio
+    from vosk import KaldiRecognizer, Model
+
+    from helpers import llm, tts
+
+    model = Model(str(resolve_model_path()))
     recognizer = KaldiRecognizer(model, 16000)
-
     bonzi_response = BonziResponse()
-    p = pyaudio.PyAudio()
-    stream = p.open(format=pyaudio.paInt16, channels=1, rate=16000, input=True, frames_per_buffer=8000, input_device_index=device_index)
+    audio = pyaudio.PyAudio()
+    stream = audio.open(
+        format=pyaudio.paInt16,
+        channels=1,
+        rate=16000,
+        input=True,
+        frames_per_buffer=8000,
+        input_device_index=device_index,
+    )
     stream.start_stream()
 
-    keywords = ["bonzi", "bones you", "bones", "ponzi", "bondi", "banking", "bouncy", "monsey", "bonds it", "bons it", "juan the", "bungie", "bons the", "bonds the", "monte", "pansy", "bonds a", "bonds a", "bundy", "bonnie", "money", "bunny"]
+    keywords = [
+        "bonzi", "bones you", "bones", "ponzi", "bondi", "banking", "bouncy",
+        "monsey", "bonds it", "bons it", "juan the", "bungie", "bons the",
+        "bonds the", "monte", "pansy", "bonds a", "bundy", "bonnie", "money", "bunny",
+    ]
     command_active = False
 
     while True:
         data = stream.read(4000, exception_on_overflow=False)
         if recognizer.AcceptWaveform(data):
-            result = recognizer.Result()
-            text = json.loads(result).get("text", "")
+            text = json.loads(recognizer.Result()).get("text", "")
             print(f"Heard: {text}")
 
             if command_active:
-                # Directly use the first captured text as the command
                 if text:
                     llm_response = llm.request(text.strip())
                     print(f"LLM response: {llm_response}")
                     tts.say(llm_response)
-                command_active = False  # Reset after processing
+                command_active = False
 
             words = text.split()
             if any(keyword in text for keyword in keywords) and len(words) < 4 and not command_active:
                 bonzi_response.play_random_response()
-                time.sleep(.45)
-                command_active = True  # Enable command capture
+                time.sleep(0.45)
+                command_active = True
+
+
+def main() -> int:
+    from helpers import mic
+
+    try:
+        resolve_model_path()
+        config = mic.load_config()
+        if config is None or config.get("prompt_every_time", False):
+            config = mic.configure_microphone()
+        listen_for_bonzi(config["device_index"])
+    except (FileNotFoundError, KeyError) as exc:
+        print(f"Startup error: {exc}")
+        return 1
+    return 0
+
 
 if __name__ == "__main__":
-    config = mic.load_config()
-    if config is None or config.get("prompt_every_time", False):
-        config = mic.configure_microphone()
-    device_index = config['device_index']
-    listen_for_bonzi(device_index)
+    raise SystemExit(main())

--- a/tests/test_mic.py
+++ b/tests/test_mic.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from helpers import mic
+
+
+class MicrophoneConfigTests(unittest.TestCase):
+    def test_missing_config_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "nested" / "mic.json"
+            with patch.dict(os.environ, {"BONZI_MIC_CONFIG": str(path)}):
+                self.assertIsNone(mic.load_config())
+
+    def test_invalid_config_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mic.json"
+            path.write_text("not-json", encoding="utf-8")
+            with patch.dict(os.environ, {"BONZI_MIC_CONFIG": str(path)}):
+                self.assertIsNone(mic.load_config())
+
+    def test_save_creates_parent_and_round_trips(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "nested" / "mic.json"
+            expected = {"device_index": 2, "prompt_every_time": False}
+            with patch.dict(os.environ, {"BONZI_MIC_CONFIG": str(path)}):
+                mic.save_config(expected)
+                self.assertEqual(mic.load_config(), expected)
+                self.assertEqual(json.loads(path.read_text(encoding="utf-8")), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import main
+
+
+class StartupTests(unittest.TestCase):
+    def test_missing_model_has_actionable_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            missing = Path(directory) / "missing-model"
+            with patch.dict(os.environ, {"BONZI_VOSK_MODEL": str(missing)}):
+                with self.assertRaisesRegex(FileNotFoundError, "BONZI_VOSK_MODEL"):
+                    main.resolve_model_path()
+
+    def test_model_override_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            model = Path(directory) / "model"
+            model.mkdir()
+            with patch.dict(os.environ, {"BONZI_VOSK_MODEL": str(model)}):
+                self.assertEqual(main.resolve_model_path(), model)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- resolve microphone configuration relative to the project root and create its parent directory when needed
- tolerate missing or malformed local microphone configuration
- lazy-load audio and Vosk dependencies so setup helpers can be tested without audio hardware
- report an actionable error when the Vosk model is missing and support `BONZI_VOSK_MODEL`
- preserve the existing project documentation while correcting the complete first-run procedure
- add standard-library regression tests for configuration and model-path handling

## Validation

- added regression tests covering missing configuration, malformed JSON, nested configuration-directory creation, configuration round trips, missing Vosk model diagnostics, and `BONZI_VOSK_MODEL` overrides
- `python -m unittest discover -s tests`: passed
- all changed Python files compile successfully
- the previously broken microphone configuration path is now resolved relative to the project root and no longer depends on a nonexistent Windows-only `config\mic_config.json` location
- missing Vosk model startup now fails with an actionable message instead of surfacing an opaque library error

## AI assistance

OpenAI GPT-5.6 Thinking assisted with repository inspection, implementation, and test drafting. Paulo Ribeiro reviewed the scope and remains responsible for the contribution.

Fixes #7
/claim #7