### PR TITLE
fix: improve first-run setup docs and fix mic config path

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,8 +14,12 @@ BonziAssist revives the classic BonziBuddy assistant in a modern, voice-activate
 
 ### Installation
 1. Clone this repository.
-2. Ensure you have [Python](https://www.python.org/downloads/) and [Visual CPP Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). installed, and then run `pip install -r requirements.txt` to install the necessary packages.
-4. Set up your environment variables. Edit the `.env.example` file in `helpers\` and follow the instructions there. `[INSTRUCTIONS='Remove this line of instructions. Fill out the info below. Rename this file, and remove the .example. It should just be ".env" now.']`
+2. Ensure you have [Python](https://www.python.org/downloads/) and [Visual CPP Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) installed, then run `pip install -r requirements.txt` to install the necessary packages.
+3. Set up your environment variables. Copy `helpers\.env.example` to `helpers\.env` and fill in your [Groq API key](https://console.groq.com) (free sign-up):
+   ```
+   LLM_PROVIDER=groq
+   GROQ_API_KEY=your-api-key-here
+   ```
 
 ### Usage
 To start BonziAssist:
@@ -23,7 +27,9 @@ To start BonziAssist:
 python main.py
 ```
 
-You will be prompted to configure your microphone settings upon the first run or if you choose to be prompted every time by the configuration settings.
+On first run you will be prompted to select a microphone. After that, say **"Bonzi"** (the wake word) and Bonzi will confirm he's listening. Then speak your command.
+
+> **Tip:** If the app doesn't respond, check that your microphone is working and that you have a working internet connection for the LLM API.
 
 ## TODO
 

--- a/helpers/.env.example
+++ b/helpers/.env.example
@@ -1,3 +1,3 @@
-INSTRUCTIONS='Remove this line of instructions. Fill out the info below. Rename this file, and remove the .example. It should just be ".env" now.'
+# Get a free API key at https://console.groq.com
 LLM_PROVIDER=groq
 GROQ_API_KEY=your-api-key-here

--- a/helpers/mic.py
+++ b/helpers/mic.py
@@ -2,7 +2,8 @@ import pyaudio
 import os
 import json
 
-CONFIG_FILE = "config\mic_config.json"
+import os
+CONFIG_FILE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "mic_config.json")
 
 def list_microphones():
     p = pyaudio.PyAudio()


### PR DESCRIPTION
Fixes issue #7

Changes:
- Fix README installation step numbering (was 1, 2, 4)
- Simplify .env.example (remove confusing INSTRUCTIONS line)
- Fix mic config path for cross-platform compatibility
- Add wake word guidance and first-run checklist
- Add Groq API key sign-up link