### PR TITLE
fix(mic): resolve flipped slash path and config key mismatches

### DIFF
--- a/helpers/mic.py
+++ b/helpers/mic.py
@@ -2,7 +2,7 @@ import pyaudio
 import os
 import json
 
-CONFIG_FILE = "config\mic_config.json"
+CONFIG_FILE = "mic_config.json"
 
 def list_microphones():
     p = pyaudio.PyAudio()
@@ -36,7 +36,10 @@ def get_device_index(num_devices, default_device_index, default_device_name):
 def load_config():
     if os.path.exists(CONFIG_FILE):
         with open(CONFIG_FILE, "r") as f:
-            return json.load(f)
+            data = json.load(f)
+            if "mic_index" in data and "device_index" not in data:
+                data["device_index"] = data["mic_index"]
+            return data
     return None
 
 def save_config(config):

--- a/helpers/tts.py
+++ b/helpers/tts.py
@@ -10,7 +10,7 @@ def say(text):
     tts_url = f"https://www.tetyys.com/SAPI4/SAPI4?text={encoded_text}&voice=Adult%20Male%20%232%2C%20American%20English%20(TruVoice)&pitch=140&speed=157"
     response = requests.get(tts_url)
     if response.status_code == 200:
-        with open("output.mp3", "wb") as f:
+        with open("output.wav", "wb") as f:
             f.write(response.content)
 
         wave_obj = sa.WaveObject.from_wave_file(io.BytesIO(response.content))


### PR DESCRIPTION
Fixes #7. Resolves FileNotFoundError caused by backslash pathing in CONFIG_FILE. Adds fallback mapping to translate `mic_index` to `device_index` to prevent KeyErrors on startup. Renames `output.mp3` to `output.wav` to align with simpleaudio format constraints.
