### PR TITLE
Fix first-run start so python main.py actually runs

### DIFF
--- a/helpers/llm.py
+++ b/helpers/llm.py
@@ -2,20 +2,30 @@ import os
 from dotenv import load_dotenv
 import litellm
 
-load_dotenv()
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+load_dotenv(os.path.join(_ROOT, ".env"))
+load_dotenv(os.path.join(_ROOT, "helpers", ".env"))
 
-groq_api_key = os.getenv("GROQ_API_KEY")
-llm_provider = os.getenv("LLM_PROVIDER")
 
-if groq_api_key is None:
-    raise ValueError("GROQ_API_KEY environment variable not found. Please set it in your .env file.")
+def _require_env():
+    groq_api_key = os.getenv("GROQ_API_KEY")
+    llm_provider = os.getenv("LLM_PROVIDER")
+    if groq_api_key is None or groq_api_key == "your-api-key-here":
+        raise ValueError(
+            "GROQ_API_KEY is missing. Copy helpers/.env.example to helpers/.env, "
+            "fill GROQ_API_KEY, then run: python main.py"
+        )
+    if llm_provider is None:
+        raise ValueError(
+            "LLM_PROVIDER is missing. Copy helpers/.env.example to helpers/.env, "
+            "set LLM_PROVIDER=groq, then run: python main.py"
+        )
+    os.environ["GROQ_API_KEY"] = groq_api_key
+    return llm_provider
 
-if llm_provider is None:
-    raise ValueError("LLM_PROVIDER environment variable not found. Please set it in your .env file.")
-
-os.environ["GROQ_API_KEY"] = groq_api_key
 
 def request(user_query, model="llama3-8b-8192", temperature=0.7, max_tokens=150):
+    llm_provider = _require_env()
     messages = [
         {"role": "system", "content": """You are a helpful new state of the art assistant, called BonziAssist. You are based on the old BonziBuddy archetecture, and have the same voice.
          You are the backend for a new project, where instead of the user typing to an LLM, they speak. Manage your responses as such.
@@ -24,14 +34,12 @@ def request(user_query, model="llama3-8b-8192", temperature=0.7, max_tokens=150)
          If the user misspells or uses the wrong words to convey something, do your best to interpret.
          If the user says anything like 'nevermind' or 'go away', simply output 'Ok.'
          If the user says a single word, or a few words strung together that don't make any sense, (after examining and trying to interpret), say 'Sorry, something went wrong.'"""},
-        {"role": "user", "content": user_query}
+        {"role": "user", "content": user_query},
     ]
-
     response = litellm.completion(
         model=f"{llm_provider}/{model}",
         messages=messages,
         temperature=temperature,
-        max_tokens=max_tokens
+        max_tokens=max_tokens,
     )
-    
     return response.choices[0].message.content

--- a/helpers/mic.py
+++ b/helpers/mic.py
@@ -2,59 +2,89 @@ import pyaudio
 import os
 import json
 
-CONFIG_FILE = "config\mic_config.json"
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONFIG_FILE = os.path.join(_ROOT, "mic_config.json")
+LEGACY_WIN_PATH = os.path.join(_ROOT, "config", "mic_config.json")
+LEGACY_LITERAL_PATH = os.path.join(_ROOT, "config\\mic_config.json")
+
+
+def _existing_config_path():
+    for path in (CONFIG_FILE, LEGACY_WIN_PATH, LEGACY_LITERAL_PATH):
+        if os.path.isfile(path):
+            return path
+    return CONFIG_FILE
+
+
+def _normalize(config):
+    if not isinstance(config, dict):
+        return config
+    if "device_index" not in config and "mic_index" in config:
+        config = dict(config)
+        config["device_index"] = config["mic_index"]
+    return config
+
 
 def list_microphones():
     p = pyaudio.PyAudio()
-    info = p.get_host_api_info_by_index(0)
-    num_devices = info.get('deviceCount')
+    try:
+        info = p.get_host_api_info_by_index(0)
+        num_devices = info.get("deviceCount")
+        default_device_index = p.get_default_input_device_info().get("index")
+        default_device_name = p.get_device_info_by_index(default_device_index).get("name")
+        for i in range(num_devices):
+            device_info = p.get_device_info_by_host_api_device_index(0, i)
+            if device_info.get("maxInputChannels") > 0:
+                suffix = " (default)" if i == default_device_index else ""
+                print(f"{i}: - {device_info.get('name')}{suffix}")
+        return default_device_name
+    finally:
+        p.terminate()
 
-    default_device_index = p.get_default_input_device_info().get('index')
-    default_device_name = p.get_device_info_by_index(default_device_index).get('name')
-
-    for i in range(num_devices):
-        device_info = p.get_device_info_by_host_api_device_index(0, i)
-        if device_info.get('maxInputChannels') > 0:
-            if i == default_device_index:
-                print(f"{i}: - {device_info.get('name')} (default)")
-            else:
-                print(f"{i}: - {device_info.get('name')}")
-    p.terminate()
-    return default_device_name
 
 def get_device_index(num_devices, default_device_index, default_device_name):
     while True:
-        user_input = input(f"Enter the Input Device id you want to use (enter = '{default_device_name}'): ").strip()
+        user_input = input(
+            f"Enter the Input Device id you want to use (enter = '{default_device_name}'): "
+        ).strip()
         if user_input == "":
-            return default_device_index  # Default to the default device if no input is given
+            return default_device_index
         if user_input.isdigit():
             device_index = int(user_input)
             if 0 <= device_index < num_devices:
                 return device_index
         print("Invalid input. Please enter a valid number.")
 
+
 def load_config():
-    if os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, "r") as f:
-            return json.load(f)
+    path = _existing_config_path()
+    if os.path.isfile(path):
+        with open(path, "r") as f:
+            return _normalize(json.load(f))
     return None
 
+
 def save_config(config):
+    os.makedirs(_ROOT, exist_ok=True)
     with open(CONFIG_FILE, "w") as f:
         json.dump(config, f, indent=4)
+
 
 def configure_microphone():
     print("Available microphones:")
     default_device_name = list_microphones()
     p = pyaudio.PyAudio()
-    num_devices = p.get_host_api_info_by_index(0).get('deviceCount')
-    default_device_index = p.get_default_input_device_info().get('index')
-    p.terminate()
+    try:
+        num_devices = p.get_host_api_info_by_index(0).get("deviceCount")
+        default_device_index = p.get_default_input_device_info().get("index")
+    finally:
+        p.terminate()
     device_index = get_device_index(num_devices, default_device_index, default_device_name)
-    prompt_every_time = input("Do you want to be prompted to select a microphone every time? (y/n): ").strip().lower()
+    prompt_every_time = input(
+        "Do you want to be prompted to select a microphone every time? (y/n): "
+    ).strip().lower()
     config = {
         "device_index": device_index,
-        "prompt_every_time": prompt_every_time == 'y'
+        "prompt_every_time": prompt_every_time == "y",
     }
     save_config(config)
     return config

--- a/main.py
+++ b/main.py
@@ -39,6 +39,10 @@ class BonziResponse:
 
 def listen_for_bonzi(device_index=None):
     model_path = "vosk/vosk-model-small-en-us-0.15"
+    if not os.path.isdir(model_path):
+        raise SystemExit(
+            f"Vosk model missing at {model_path}. Put the small English model in that folder, then run: python main.py"
+        )
     model = Model(model_path)
     recognizer = KaldiRecognizer(model, 16000)
 
@@ -58,22 +62,31 @@ def listen_for_bonzi(device_index=None):
             print(f"Heard: {text}")
 
             if command_active:
-                # Directly use the first captured text as the command
                 if text:
                     llm_response = llm.request(text.strip())
                     print(f"LLM response: {llm_response}")
                     tts.say(llm_response)
-                command_active = False  # Reset after processing
+                command_active = False
 
             words = text.split()
             if any(keyword in text for keyword in keywords) and len(words) < 4 and not command_active:
                 bonzi_response.play_random_response()
                 time.sleep(.45)
-                command_active = True  # Enable command capture
+                command_active = True
+
+def _device_index(config):
+    if not config:
+        return None
+    if "device_index" in config:
+        return config["device_index"]
+    if "mic_index" in config:
+        return config["mic_index"]
+    return None
 
 if __name__ == "__main__":
+    print("BonziAssist: run python main.py, pick a mic if asked, then say Bonzi.")
     config = mic.load_config()
-    if config is None or config.get("prompt_every_time", False):
+    if config is None or config.get("prompt_every_time", False) or _device_index(config) is None:
         config = mic.configure_microphone()
-    device_index = config['device_index']
+    device_index = _device_index(config)
     listen_for_bonzi(device_index)


### PR DESCRIPTION
Fixes #7
/claim #7

First-run was crashing before the mic prompt: Windows config path, mic_index vs device_index, and Groq env loaded at import. This makes python main.py start, prompt for a mic, and fail with a clear message if Vosk or .env is missing.